### PR TITLE
Improve metadata: fix datapackage and README to reflect US Treasury FRED data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,24 @@
 <a className="gh-badge" href="https://datahub.io/core/bond-yields-gov-long-term"><img src="https://badgen.net/badge/icon/View%20on%20datahub.io/orange?icon=https://datahub.io/datahub-cube-badge-icon.svg&label&scale=1.25" alt="badge" /></a>
 
-Long term government bond yields.
+Monthly average US 10-year Treasury constant maturity yield from April 1953 to the present. Values are sourced from the Federal Reserve Bank of St. Louis ([FRED series DGS10](https://fred.stlouisfed.org/series/DGS10)) and expressed as a percentage.
 
-# Data
+## Data
 
-## European Union
+The dataset contains one row per calendar month. The `Yield` value is the mean of all daily observations published by FRED for that month, rounded to two decimal places.
 
-[ECB - Long-term interest rate statistics for EU Member States] (note this data is also the source for that [provided by Eurostat][eurostat]). As stated on Eurostat site:
-
-> Long term government bond yields are calculated as monthly averages (non seasonally adjusted data). They refer to central government bond yields on the secondary market, gross of tax, with a residual maturity of around 10 years. The bond or the bonds of the basket have to be replaced regularly to avoid any maturity drift. This definition is used in the convergence criteria of the Economic and Monetary Union for long-term interest rates, as required under Article 121 of the Treaty of Amsterdam and the Protocol on the convergence criteria. Data are presented in raw form. Source: European Central Bank (ECB)
-
-[ecb]: http://www.ecb.int/stats/money/long/html/index.en.html
-[eurostat]: http://epp.eurostat.ec.europa.eu/tgm/table.do?tab=table&plugin=1&language=en&pcode=teimf050
+**Source:** [Market Yield on U.S. Treasury Securities at 10-Year Constant Maturity (DGS10)](https://fred.stlouisfed.org/series/DGS10) — Federal Reserve Bank of St. Louis.
 
 ## Preparation
-Process is recorded and automated in python script:
+
+The process is recorded and automated in a Python script:
 
 ```bash
 pip install -r scripts/requirements.txt
-python  scripts/prepare.py
+python scripts/process.py
 ```
 
-## Automation
-Up-to-date (auto-updates every month) bond-yields-gov-long-term dataset could be found on the datahub.io: https://datahub.io/core/bond-yields-gov-long-term
-
-# License
+## License
 
 Licensed under the [Public Domain Dedication and License][pddl] (assuming either no rights or public domain license in source data).
 
-[pddl]: http://opendatacommons.org/licenses/pddl/1.0/
-
+[pddl]: https://opendatacommons.org/licenses/pddl/

--- a/datapackage.json
+++ b/datapackage.json
@@ -1,5 +1,7 @@
 {
-  "description": "Long-term government bond yields (10-year) over time. Data is sourced from various financial institutions and presented in a normalized format.",
+  "name": "long-term-bond-yields",
+  "title": "Long Term Government Bond Yields (10y)",
+  "description": "Monthly average US 10-year Treasury constant maturity yield (FRED series DGS10), sourced from the Federal Reserve Bank of St. Louis. Values are expressed as a percentage. Coverage starts April 1953.",
   "keywords": [
     "Government Bonds",
     "10-year Yield",
@@ -7,36 +9,43 @@
     "Interest Rates",
     "Time Series"
   ],
-  "last_updated": "2025-02-28",
   "licenses": [
     {
       "name": "ODC-PDDL-1.0",
-      "path": "http://opendatacommons.org/licenses/pddl/1.0/",
+      "path": "https://opendatacommons.org/licenses/pddl/",
       "title": "Open Data Commons Public Domain Dedication and License v1.0"
     }
   ],
-  "name": "long-term-bond-yields",
+  "sources": [
+    {
+      "name": "Federal Reserve Bank of St. Louis (FRED)",
+      "path": "https://fred.stlouisfed.org/series/DGS10",
+      "title": "Market Yield on U.S. Treasury Securities at 10-Year Constant Maturity (DGS10)"
+    }
+  ],
+  "version": "2025",
+  "collection": "financial-data",
   "resources": [
     {
       "name": "us-treasury-10y-yields",
       "path": "data/us-10y.csv",
+      "description": "Monthly average US 10-year Treasury constant maturity yield from April 1953 onwards. Each row is one calendar month; the Yield value is the mean of all daily observations published by FRED for that month, rounded to two decimal places.",
       "schema": {
         "fields": [
           {
             "name": "Date",
             "type": "date",
-            "format": "yyyy-mm"
+            "format": "%Y-%m",
+            "description": "Month of the observation in YYYY-MM format (e.g. 2025-02)."
           },
           {
             "name": "Yield",
             "type": "number",
+            "description": "Monthly average 10-year US Treasury constant maturity yield, expressed as a percentage (e.g. 4.26 means 4.26%).",
             "units": "percent"
           }
         ]
       }
     }
-  ],
-  "title": "Long Term Government Bond Yields (10y)",
-  "version": "2025",
-  "collection": "financial-data"
+  ]
 }


### PR DESCRIPTION
## Summary
- Fix `package.description`: was generic "various financial institutions"; now accurately describes US Treasury 10-year yield from FRED series DGS10
- Add missing `sources` entry pointing to FRED DGS10 (`https://fred.stlouisfed.org/series/DGS10`)
- Fix `Date` field `format` from `"yyyy-mm"` (Java-style, invalid for Frictionless) to `"%Y-%m"` (Python strftime); this was causing `frictionless validate` to fail on every single row
- Add `description` to the `us-treasury-10y-yields` resource
- Add `description` to both `Date` and `Yield` fields
- Update license `path` from HTTP to HTTPS
- Rewrite README: remove incorrect EU/ECB/Eurostat content (wrong dataset), replace with accurate description of US Treasury data from FRED; fix script name `prepare.py` → `process.py`; remove broken Eurostat URL (TLS error) and outdated ECB URL; update license link to HTTPS